### PR TITLE
GH#1: add configurable Docker host IP via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+HOST_IP=127.0.0.1
 PORT=3800
 SESSION_SECRET=change-this-in-production
 COOKIE_SECURE=false

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ npm run dev
 Copy `.env.example` to `.env` if you want to override the defaults:
 
 ```env
+HOST_IP=127.0.0.1                         # Docker bind IP (use your LAN IP to expose it)
 PORT=3800                                 # API port
 SESSION_SECRET=change-this-in-production  # Cookie signing secret
 COOKIE_SECURE=false                       # Set to true behind HTTPS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     build: .
     container_name: discographic
     ports:
-      - "3800:3800"
+      - "${HOST_IP:-127.0.0.1}:${PORT:-3800}:3800"
     environment:
-      PORT: 3800
+      PORT: ${PORT:-3800}
       SESSION_SECRET: ${SESSION_SECRET:-discographic-dev-secret}
       COOKIE_SECURE: ${COOKIE_SECURE:-false}
     volumes:


### PR DESCRIPTION
## Summary
- add HOST_IP to .env.example
- use HOST_IP and PORT in docker-compose.yml port binding
- document the new option in README.md

## Verification
- docker compose config

Closes #1


---
[aidevops.sh](https://aidevops.sh) v3.5.462 plugin for [OpenCode](https://opencode.ai) v1.2.20 with gpt-5.4 spent 4h 15m and 18,845 tokens on this as a headless worker.