### PR TITLE
Render ColumnToggle popover via portal

### DIFF
--- a/src/components/ColumnToggle.jsx
+++ b/src/components/ColumnToggle.jsx
@@ -1,36 +1,60 @@
-import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { COLUMNS, MANDATORY } from '../lib/columns';
 import { useI18n } from '../lib/I18nContext';
 
 function ColumnToggle({ visibleColumns, onToggle }) {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
-  const containerRef = useRef(null);
+  const buttonRef = useRef(null);
+  const panelRef = useRef(null);
+
+  const updatePosition = useCallback(() => {
+    if (!open || !buttonRef.current || !panelRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    const panel = panelRef.current;
+    panel.style.top = `${rect.bottom + 8}px`;
+    panel.style.left = `${Math.max(8, rect.right - panel.offsetWidth)}px`;
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
 
+    // Position once after render
+    requestAnimationFrame(updatePosition);
+
     function handleClickOutside(event) {
-      if (containerRef.current && !containerRef.current.contains(event.target)) {
+      if (
+        buttonRef.current && !buttonRef.current.contains(event.target) &&
+        panelRef.current && !panelRef.current.contains(event.target)
+      ) {
         setOpen(false);
       }
     }
 
+    window.addEventListener('scroll', updatePosition, true);
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open]);
+    return () => {
+      window.removeEventListener('scroll', updatePosition, true);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [open, updatePosition]);
 
   return (
-    <div className="relative" ref={containerRef}>
+    <>
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setOpen((prev) => !prev)}
         className="secondary-button"
       >
         {t('collection.columns')}
       </button>
-      {open && (
-        <div className="absolute right-0 top-full z-30 mt-2 min-w-[200px] rounded-2xl border border-white/10 bg-slate-950/90 p-3 shadow-lg backdrop-blur-xl">
+      {open && createPortal(
+        <div
+          ref={panelRef}
+          className="fixed z-50 min-w-[200px] rounded-2xl border border-white/10 bg-slate-950/90 p-3 shadow-lg backdrop-blur-xl"
+        >
           {COLUMNS.map((col) => {
             const isMandatory = MANDATORY.includes(col.id);
             const isChecked = isMandatory || visibleColumns.includes(col.id);
@@ -51,9 +75,10 @@ function ColumnToggle({ visibleColumns, onToggle }) {
               </label>
             );
           })}
-        </div>
+        </div>,
+        document.body
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/pages/Collection.jsx
+++ b/src/pages/Collection.jsx
@@ -180,7 +180,7 @@ function Collection() {
 
   return (
     <div className="space-y-6">
-      <section className="glass-panel relative z-20 flex flex-col gap-4 p-5 xl:flex-row xl:items-center xl:justify-between">
+      <section className="glass-panel relative flex flex-col gap-4 p-5 xl:flex-row xl:items-center xl:justify-between">
         <div>
           <p className="text-sm uppercase tracking-[0.35em] text-brand-200">{t('collection.eyebrow')}</p>
           <h2 className="mt-2 font-display text-4xl text-white">{t('collection.title')}</h2>


### PR DESCRIPTION
## Summary

- Render the column toggle dropdown via `createPortal` to `document.body` instead of absolute positioning within a `relative` parent
- Position the panel using `getBoundingClientRect()` with scroll-aware repositioning
- Remove the `z-20` hack from the collection section header — no longer needed since the portal escapes the stacking context entirely
- The portal panel uses `fixed z-50` for reliable layering over any content

## Why

The previous `z-20`/`z-30` layering between the section and the popover was fragile — any future z-index addition could break it. Portals are the standard React pattern for dropdowns that need to escape parent overflow/stacking.

## Files changed

- `src/components/ColumnToggle.jsx` — portal rendering, ref-based positioning
- `src/pages/Collection.jsx` — remove `z-20` from section

## Test plan

- [x] Open column toggle — panel appears aligned to button
- [x] Scroll page — panel repositions correctly
- [x] Click outside — panel closes
- [x] No z-index conflicts with other UI elements

Closes #9 (item 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)