### PR TITLE
Restrict preferences API to a whitelist of known keys

### DIFF
--- a/server/routes/account.js
+++ b/server/routes/account.js
@@ -65,17 +65,24 @@ router.post('/reset', (req, res) => {
   return res.json({ ok: true, message: req.t('backend.account.reset') });
 });
 
+// Whitelist of valid preference keys. Add new entries here when introducing
+// new user-facing preferences that should be persisted via the API.
+const ALLOWED_PREFERENCE_KEYS = new Set([
+  'collection_visible_columns',
+  'currency',
+]);
+
 router.get('/preferences/:key', (req, res) => {
-  if (!/^[\w]+$/.test(req.params.key)) {
-    return res.status(400).json({ error: 'Invalid key' });
+  if (!ALLOWED_PREFERENCE_KEYS.has(req.params.key)) {
+    return res.status(400).json({ error: 'Unknown preference key' });
   }
   const value = getSettingForUser(req.session.userId, req.params.key);
   res.json({ value });
 });
 
 router.put('/preferences/:key', (req, res) => {
-  if (!/^[\w]+$/.test(req.params.key)) {
-    return res.status(400).json({ error: 'Invalid key' });
+  if (!ALLOWED_PREFERENCE_KEYS.has(req.params.key)) {
+    return res.status(400).json({ error: 'Unknown preference key' });
   }
   const { value } = req.body;
   if (value === undefined) {


### PR DESCRIPTION
## Summary

- Replace the permissive `\w+` regex validation on `/account/preferences/:key` with an explicit `ALLOWED_PREFERENCE_KEYS` Set
- Currently allowed keys: `collection_visible_columns`, `currency`
- Unknown keys return `400 Unknown preference key`
- Added a comment above the Set explaining where to add new keys

## Why

The previous regex allowed any word-character key to be read/written. While authenticated-only, a whitelist is safer and makes the API contract explicit.

## Files changed

- `server/routes/account.js` — whitelist Set, updated validation in both GET and PUT

## Test plan

- [x] `collection_visible_columns` and `currency` still work via API
- [x] Unknown keys like `foo` return 400
- [x] Existing preference tests still pass

Closes #9 (item 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)