### PR TITLE
Debounce column visibility preference save

### DIFF
--- a/src/pages/Collection.jsx
+++ b/src/pages/Collection.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import CollectionTable from '../components/CollectionTable';
 import ColumnToggle from '../components/ColumnToggle';
@@ -46,6 +46,7 @@ function Collection() {
   const [payload, setPayload] = useState({ releases: [], pagination: {}, filters: {} });
   const [loading, setLoading] = useState(true);
   const [visibleColumns, setVisibleColumns] = useState(DEFAULT_VISIBLE);
+  const saveColumnsTimer = useRef(null);
 
   async function load(nextPage = page, nextFilters = filters, nextSortBy = sortBy, nextSortOrder = sortOrder) {
     try {
@@ -128,7 +129,10 @@ function Collection() {
       const next = prev.includes(columnId)
         ? prev.filter((id) => id !== columnId)
         : [...prev, columnId];
-      api.setPreference('collection_visible_columns', JSON.stringify(next)).catch(() => {});
+      clearTimeout(saveColumnsTimer.current);
+      saveColumnsTimer.current = setTimeout(() => {
+        api.setPreference('collection_visible_columns', JSON.stringify(next)).catch(() => {});
+      }, 500);
 
       // If the currently sorted column is being hidden, reset sort to artist
       const hiddenColumnDef = COLUMNS.find((c) => c.id === columnId);


### PR DESCRIPTION
## Summary

- Add a 500ms debounce to the `api.setPreference` call in `handleColumnToggle`
- Rapid column toggling now coalesces into a single API request instead of one per click
- Uses a simple `useRef` + `setTimeout`/`clearTimeout` pattern — no new dependencies

## Why

Each column toggle immediately fired an API call. While not breaking, rapid toggling (e.g., unchecking three columns quickly) sent three sequential requests when one would suffice.

## Files changed

- `src/pages/Collection.jsx` — added `useRef` import, `saveColumnsTimer` ref, debounced the `setPreference` call

## Test plan

- [x] Toggle a column — preference saves after 500ms
- [x] Toggle multiple columns rapidly — only one API call fires
- [x] Column visibility updates immediately in the UI (no delay on visual toggle)

Closes #9 (item 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)