### PR TITLE
Fix infinite enrichment loop and configurable dev proxy

### DIFF
--- a/server/routes/sync.js
+++ b/server/routes/sync.js
@@ -168,7 +168,7 @@ async function runSync({ userId, logId, discogs, locale }) {
   `).run(totalSynced, logId, userId);
 
   const pending = db.prepare(
-    "SELECT COUNT(*) AS count FROM releases WHERE user_id = ? AND (estimated_value IS NULL OR country IS NULL OR country = '')"
+    "SELECT COUNT(*) AS count FROM releases WHERE user_id = ? AND (estimated_value IS NULL)"
   ).get(userId).count;
 
   setSyncState(userId, {
@@ -348,7 +348,7 @@ async function runEnrichAll({ userId, discogs }) {
   enrichRunning.add(userId);
 
   try {
-    const ENRICH_CONDITION = "estimated_value IS NULL OR country IS NULL OR country = ''";
+    const ENRICH_CONDITION = "estimated_value IS NULL";
     const totalPending = db.prepare(
       `SELECT COUNT(*) AS count FROM releases WHERE user_id = ? AND (${ENRICH_CONDITION})`
     ).get(userId).count;

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:3800',
+        target: `http://localhost:${process.env.VITE_API_PORT || 3800}`,
         changeOrigin: true
       }
     }


### PR DESCRIPTION
## Summary

- **Enrichment loop fix**: Remove `country IS NULL OR country = ''` from the enrichment pending condition. Releases where Discogs has no country data were re-selected as "pending" on every enrichment run, creating an infinite loop. The condition now only checks `estimated_value IS NULL` — country is still populated when available but its absence no longer re-triggers enrichment.
- **Dev proxy fix**: Make the Vite dev proxy target configurable via `VITE_API_PORT` env variable (defaults to 3800). Without this, the dev frontend always proxied to port 3800 (Docker production) even when running a separate dev server on another port.

## Root cause

Two releases in the collection (GG Allin "You Give Love A Bad Name", Camel "The Snow Goose") have no country in Discogs. The enrichment set `estimated_value` (removing them from that check) but `country` stayed empty, so they matched `country IS NULL OR country = ''` on every run — forever.

## Usage

```bash
# Dev server on custom port
PORT=3802 npm run dev:server
VITE_API_PORT=3802 npm run dev -- --host 0.0.0.0
```

## Test plan

- [x] 232 tests passing
- [x] Enrichment completes and does not restart for country-less releases
- [x] `VITE_API_PORT=3802` correctly proxies to port 3802
- [x] Default (no env) still proxies to 3800

🤖 Generated with [Claude Code](https://claude.com/claude-code)