### PR TITLE
refactor: share marketplace status contract

### DIFF
--- a/server/routes/collection.js
+++ b/server/routes/collection.js
@@ -2,7 +2,8 @@ import express from 'express';
 import db, { getSettingForUser, hydrateRelease, parseJson, stringifyJson } from '../db.js';
 import { getDiscogsClientForUser, requireAuth } from '../middleware/auth.js';
 import { DEFAULT_CURRENCY, convertReleasePrices, normalizeCurrency } from '../services/exchangeRates.js';
-import { fetchMarketplaceValue, MARKETPLACE_STATUS } from '../services/marketplaceValue.js';
+import { MARKETPLACE_STATUS } from '../../shared/contracts/marketplace.js';
+import { fetchMarketplaceValue } from '../services/marketplaceValue.js';
 import { parseStoredNotes, replaceNoteText, resolveNoteFieldId } from '../services/notes.js';
 import { buildReleaseFilterWhere, getCollectionFilterOptions } from '../services/releaseFilters.js';
 

--- a/server/routes/stats.js
+++ b/server/routes/stats.js
@@ -4,7 +4,7 @@ import { requireAuth } from '../middleware/auth.js';
 import { DEFAULT_CURRENCY, convertAmount, normalizeCurrency } from '../services/exchangeRates.js';
 import { countMeaningfulNoteRows } from '../services/notes.js';
 import { normalizeDashboardStats } from '../../shared/contracts/dashboardStats.js';
-import { MARKETPLACE_STATUS } from '../services/marketplaceValue.js';
+import { MARKETPLACE_STATUS } from '../../shared/contracts/marketplace.js';
 
 const router = express.Router();
 

--- a/server/routes/sync.js
+++ b/server/routes/sync.js
@@ -6,7 +6,8 @@ import { translate } from '../../shared/i18n.js';
 import { DEFAULT_CURRENCY, convertAmountWithRates, getExchangeSnapshot } from '../services/exchangeRates.js';
 import { pruneUnseenReleases } from '../services/collectionReconcile.js';
 import { ENRICH_CONDITION, getPendingEnrichmentCount, getPendingEnrichmentRows } from '../services/enrichmentQueue.js';
-import { fetchMarketplaceValue, MARKETPLACE_STATUS } from '../services/marketplaceValue.js';
+import { MARKETPLACE_STATUS } from '../../shared/contracts/marketplace.js';
+import { fetchMarketplaceValue } from '../services/marketplaceValue.js';
 
 const router = express.Router();
 const PER_PAGE = 100;

--- a/server/services/dbMigrations.js
+++ b/server/services/dbMigrations.js
@@ -1,4 +1,4 @@
-import { MARKETPLACE_STATUS } from './marketplaceValue.js';
+import { MARKETPLACE_STATUS } from '../../shared/contracts/marketplace.js';
 
 function hasColumn(db, tableName, columnName) {
   return db

--- a/server/services/enrichmentQueue.js
+++ b/server/services/enrichmentQueue.js
@@ -1,4 +1,4 @@
-import { RETRYABLE_MARKETPLACE_STATUSES } from './marketplaceValue.js';
+import { RETRYABLE_MARKETPLACE_STATUSES } from '../../shared/contracts/marketplace.js';
 
 const quotedStatuses = RETRYABLE_MARKETPLACE_STATUSES
   .map((status) => `'${status}'`)

--- a/server/services/marketplaceValue.js
+++ b/server/services/marketplaceValue.js
@@ -1,16 +1,5 @@
+import { MARKETPLACE_STATUS } from '../../shared/contracts/marketplace.js';
 import { DEFAULT_CURRENCY } from './exchangeRates.js';
-
-export const MARKETPLACE_STATUS = {
-  PENDING: 'pending',
-  PRICED: 'priced',
-  UNAVAILABLE: 'unavailable',
-  FAILED: 'failed'
-};
-
-export const RETRYABLE_MARKETPLACE_STATUSES = [
-  MARKETPLACE_STATUS.PENDING,
-  MARKETPLACE_STATUS.FAILED
-];
 
 export async function fetchMarketplaceValue(discogs, releaseId, currency = DEFAULT_CURRENCY) {
   try {

--- a/shared/contracts/marketplace.js
+++ b/shared/contracts/marketplace.js
@@ -1,0 +1,26 @@
+export const MARKETPLACE_STATUS = Object.freeze({
+  PENDING: 'pending',
+  PRICED: 'priced',
+  UNAVAILABLE: 'unavailable',
+  FAILED: 'failed'
+});
+
+export const RETRYABLE_MARKETPLACE_STATUSES = Object.freeze([
+  MARKETPLACE_STATUS.PENDING,
+  MARKETPLACE_STATUS.FAILED
+]);
+
+const MARKETPLACE_STATUS_LABEL_KEYS = Object.freeze({
+  [MARKETPLACE_STATUS.PENDING]: 'collection.pricePending',
+  [MARKETPLACE_STATUS.FAILED]: 'collection.priceFailed',
+  [MARKETPLACE_STATUS.UNAVAILABLE]: 'collection.priceUnavailable'
+});
+
+export function getMarketplaceStatusLabelKey(status) {
+  return MARKETPLACE_STATUS_LABEL_KEYS[status] || 'collection.priceUnknown';
+}
+
+export function hasPricedMarketplaceValue(release) {
+  const value = Number(release?.estimated_value);
+  return release?.marketplace_status === MARKETPLACE_STATUS.PRICED && Number.isFinite(value) && value > 0;
+}

--- a/src/components/CollectionTable.jsx
+++ b/src/components/CollectionTable.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { getMarketplaceStatusLabelKey, hasPricedMarketplaceValue } from '../../shared/contracts/marketplace.js';
 import { formatCurrency, joinNames } from '../lib/format';
 import { useI18n } from '../lib/I18nContext';
 import { COLUMNS } from '../lib/columns';
@@ -35,17 +36,11 @@ function SortButton({ label, column, sortBy, sortOrder, onSort }) {
 }
 
 function MarketplaceValue({ release, currency, t }) {
-  if (release.marketplace_status === 'priced' && release.estimated_value != null) {
+  if (hasPricedMarketplaceValue(release)) {
     return <span className="text-brand-100">{formatCurrency(release.estimated_value, currency)}</span>;
   }
 
-  const labelKey = {
-    pending: 'collection.pricePending',
-    failed: 'collection.priceFailed',
-    unavailable: 'collection.priceUnavailable'
-  }[release.marketplace_status] || 'collection.priceUnknown';
-
-  return <span className="text-xs text-slate-500">{t(labelKey)}</span>;
+  return <span className="text-xs text-slate-500">{t(getMarketplaceStatusLabelKey(release.marketplace_status))}</span>;
 }
 
 const RENDERERS = {

--- a/tests/enrich-progress.test.js
+++ b/tests/enrich-progress.test.js
@@ -4,7 +4,7 @@ import { existsSync, unlinkSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { ENRICH_CONDITION, getPendingEnrichmentCount, getPendingEnrichmentRows } from '../server/services/enrichmentQueue.js';
-import { MARKETPLACE_STATUS } from '../server/services/marketplaceValue.js';
+import { MARKETPLACE_STATUS } from '../shared/contracts/marketplace.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/tests/marketplace-contract.test.js
+++ b/tests/marketplace-contract.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MARKETPLACE_STATUS,
+  RETRYABLE_MARKETPLACE_STATUSES,
+  getMarketplaceStatusLabelKey,
+  hasPricedMarketplaceValue
+} from '../shared/contracts/marketplace.js';
+
+describe('marketplace contract', () => {
+  it('defines shared marketplace statuses used by server and client code', () => {
+    expect(MARKETPLACE_STATUS).toEqual({
+      PENDING: 'pending',
+      PRICED: 'priced',
+      UNAVAILABLE: 'unavailable',
+      FAILED: 'failed'
+    });
+    expect(RETRYABLE_MARKETPLACE_STATUSES).toEqual([
+      MARKETPLACE_STATUS.PENDING,
+      MARKETPLACE_STATUS.FAILED
+    ]);
+  });
+
+  it('maps marketplace statuses to collection price label keys', () => {
+    expect(getMarketplaceStatusLabelKey(MARKETPLACE_STATUS.PENDING)).toBe('collection.pricePending');
+    expect(getMarketplaceStatusLabelKey(MARKETPLACE_STATUS.FAILED)).toBe('collection.priceFailed');
+    expect(getMarketplaceStatusLabelKey(MARKETPLACE_STATUS.UNAVAILABLE)).toBe('collection.priceUnavailable');
+    expect(getMarketplaceStatusLabelKey('not-a-status')).toBe('collection.priceUnknown');
+  });
+
+  it('identifies records with a confirmed positive marketplace value', () => {
+    expect(hasPricedMarketplaceValue({ marketplace_status: MARKETPLACE_STATUS.PRICED, estimated_value: 12.5 })).toBe(true);
+    expect(hasPricedMarketplaceValue({ marketplace_status: MARKETPLACE_STATUS.PRICED, estimated_value: 0 })).toBe(false);
+    expect(hasPricedMarketplaceValue({ marketplace_status: MARKETPLACE_STATUS.FAILED, estimated_value: 12.5 })).toBe(false);
+    expect(hasPricedMarketplaceValue({ marketplace_status: MARKETPLACE_STATUS.PRICED, estimated_value: null })).toBe(false);
+  });
+});

--- a/tests/marketplace-status-migration.test.js
+++ b/tests/marketplace-status-migration.test.js
@@ -4,7 +4,7 @@ import { existsSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { migrateMarketplaceStatus } from '../server/services/dbMigrations.js';
-import { MARKETPLACE_STATUS } from '../server/services/marketplaceValue.js';
+import { MARKETPLACE_STATUS } from '../shared/contracts/marketplace.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/tests/marketplace-value.test.js
+++ b/tests/marketplace-value.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { fetchMarketplaceValue, MARKETPLACE_STATUS } from '../server/services/marketplaceValue.js';
+import { MARKETPLACE_STATUS } from '../shared/contracts/marketplace.js';
+import { fetchMarketplaceValue } from '../server/services/marketplaceValue.js';
 
 describe('fetchMarketplaceValue', () => {
   let logSpy;


### PR DESCRIPTION
## Summary
- Move marketplace statuses and retryability rules into a shared contract module
- Add label-key and positive priced-value helpers for client/server consistency
- Replace frontend hard-coded marketplace status strings with shared helpers

## Test Plan
- [x] npm test -- tests/marketplace-contract.test.js tests/marketplace-value.test.js tests/enrich-progress.test.js tests/marketplace-status-migration.test.js tests/dashboard-stats-contract.test.js
- [x] npm test
- [x] npm run build