### PR TITLE
fix: clean legacy zero marketplace values

### DIFF
--- a/server/services/dbMigrations.js
+++ b/server/services/dbMigrations.js
@@ -7,6 +7,14 @@ function hasColumn(db, tableName, columnName) {
     .some((column) => column.name === columnName);
 }
 
+function clearLegacyZeroEstimatedValues(db) {
+  db.prepare(`
+    UPDATE releases
+    SET estimated_value = NULL
+    WHERE estimated_value = 0
+  `).run();
+}
+
 export function migrateMarketplaceStatus(db) {
   const justAdded = !hasColumn(db, 'releases', 'marketplace_status');
   if (justAdded) {
@@ -21,6 +29,7 @@ export function migrateMarketplaceStatus(db) {
       SET marketplace_status = ?
       WHERE marketplace_status = 'ready'
     `).run(MARKETPLACE_STATUS.PRICED);
+    clearLegacyZeroEstimatedValues(db);
     return;
   }
 
@@ -38,9 +47,5 @@ export function migrateMarketplaceStatus(db) {
     MARKETPLACE_STATUS.PENDING
   );
 
-  db.prepare(`
-    UPDATE releases
-    SET estimated_value = NULL
-    WHERE estimated_value = 0
-  `).run();
+  clearLegacyZeroEstimatedValues(db);
 }

--- a/tests/marketplace-status-migration.test.js
+++ b/tests/marketplace-status-migration.test.js
@@ -73,6 +73,24 @@ describe('migrateMarketplaceStatus', () => {
     expect(row.marketplace_status).toBe(MARKETPLACE_STATUS.PRICED);
   });
 
+  it('clears legacy zero estimated values when marketplace_status already exists', () => {
+    db.exec(`ALTER TABLE releases ADD COLUMN marketplace_status TEXT DEFAULT '${MARKETPLACE_STATUS.PENDING}'`);
+    insertRow({ release_id: 1, instance_id: 1, estimated_value: 0 });
+    insertRow({ release_id: 2, instance_id: 2, estimated_value: 0 });
+    insertRow({ release_id: 3, instance_id: 3, estimated_value: 20 });
+    db.prepare('UPDATE releases SET marketplace_status = ? WHERE release_id = 2').run(MARKETPLACE_STATUS.UNAVAILABLE);
+    db.prepare('UPDATE releases SET marketplace_status = ? WHERE release_id = 3').run(MARKETPLACE_STATUS.PRICED);
+
+    migrateMarketplaceStatus(db);
+
+    const rows = db.prepare('SELECT release_id, marketplace_status, estimated_value FROM releases ORDER BY release_id').all();
+    expect(rows).toEqual([
+      { release_id: 1, marketplace_status: MARKETPLACE_STATUS.PENDING, estimated_value: null },
+      { release_id: 2, marketplace_status: MARKETPLACE_STATUS.UNAVAILABLE, estimated_value: null },
+      { release_id: 3, marketplace_status: MARKETPLACE_STATUS.PRICED, estimated_value: 20 }
+    ]);
+  });
+
   it('preserves existing non-default statuses on re-run', () => {
     insertRow({ release_id: 1, instance_id: 1, estimated_value: 15 });
     migrateMarketplaceStatus(db);


### PR DESCRIPTION
## Summary
- Make marketplace status migration clear legacy zero estimated values on every run
- Preserve positive priced values while nulling fake zero values for existing migrated databases
- Add regression coverage for databases where marketplace_status already exists

## Test Plan
- [x] npm test -- tests/marketplace-status-migration.test.js
- [x] npm test
- [x] npm run build