### PR TITLE
fix: normalize marketplace fetch errors

### DIFF
--- a/server/services/marketplaceValue.js
+++ b/server/services/marketplaceValue.js
@@ -1,6 +1,18 @@
 import { MARKETPLACE_STATUS } from '../../shared/contracts/marketplace.js';
 import { DEFAULT_CURRENCY } from './exchangeRates.js';
 
+function getErrorMessage(error) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (error == null) {
+    return 'Unknown marketplace error';
+  }
+
+  return String(error);
+}
+
 export async function fetchMarketplaceValue(discogs, releaseId, currency = DEFAULT_CURRENCY) {
   try {
     const stats = await discogs.getMarketplaceStats(releaseId, currency);
@@ -21,11 +33,12 @@ export async function fetchMarketplaceValue(discogs, releaseId, currency = DEFAU
       error: null
     };
   } catch (error) {
-    console.log('[marketplace-value] fetch failed:', releaseId, error.message);
+    const message = getErrorMessage(error);
+    console.log('[marketplace-value] fetch failed:', releaseId, message);
     return {
       estimatedValue: null,
       marketplaceStatus: MARKETPLACE_STATUS.FAILED,
-      error: error.message
+      error: message
     };
   }
 }

--- a/tests/marketplace-value.test.js
+++ b/tests/marketplace-value.test.js
@@ -53,6 +53,24 @@ describe('fetchMarketplaceValue', () => {
     expect(logged).toContain('456');
   });
 
+  it('returns FAILED with a normalized message when discogs throws a non-Error value', async () => {
+    const discogs = {
+      getMarketplaceStats: async () => {
+        throw 'rate limited';
+      }
+    };
+    const result = await fetchMarketplaceValue(discogs, 654);
+
+    expect(result).toEqual({
+      estimatedValue: null,
+      marketplaceStatus: MARKETPLACE_STATUS.FAILED,
+      error: 'rate limited'
+    });
+    const logged = logSpy.mock.calls.flat().join(' ');
+    expect(logged).toContain('rate limited');
+    expect(logged).toContain('654');
+  });
+
   it('returns UNAVAILABLE when marketplace stats are malformed', async () => {
     const discogs = { getMarketplaceStats: async () => ({ lowest_price: { value: 'not-a-price' } }) };
     const result = await fetchMarketplaceValue(discogs, 789);


### PR DESCRIPTION
## Summary
- Normalize non-Error marketplace fetch failures into safe string messages
- Use the normalized message for both logs and service results
- Add regression coverage for non-Error throws from the Discogs stats boundary

## Test Plan
- [x] npm test -- tests/marketplace-value.test.js
- [x] npm test
- [x] npm run build