### PR TITLE
chore: remove unused exports

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -294,9 +294,6 @@ export function setSettingForUser(userId, key, value) {
   `).run(userId, key, String(value));
 }
 
-export function getUserByUsername(username) {
-  return db.prepare('SELECT * FROM users WHERE username = ?').get(username);
-}
 
 export function getUserById(id) {
   return db.prepare('SELECT id, username, role, created_at FROM users WHERE id = ?').get(id);

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -30,7 +30,7 @@ export function getCurrentUser(req) {
   return getUserById(req.session.userId);
 }
 
-export function requireDiscogsAccount(req) {
+function requireDiscogsAccount(req) {
   const account = getDiscogsAccount(req.session.userId);
   if (!account) {
     throw new Error(req.t('backend.auth.configureDiscogs'));

--- a/server/services/coverMedia.js
+++ b/server/services/coverMedia.js
@@ -10,7 +10,7 @@ const coversDir = join(__dirname, '..', '..', 'data', 'covers');
 const REMOTE_IMAGE_HOSTS = new Set(['i.discogs.com', 'img.discogs.com']);
 const USER_AGENT = 'Discographic/1.0';
 
-export const COVER_VARIANTS = {
+const COVER_VARIANTS = {
   detail: { width: 720, quality: 84 },
   wall: { width: 320, quality: 78 },
   tapete: { width: 220, quality: 88 },

--- a/server/services/exchangeRates.js
+++ b/server/services/exchangeRates.js
@@ -141,4 +141,4 @@ export async function convertReleasePrices(release, displayCurrency) {
   };
 }
 
-export { SUPPORTED_CURRENCIES, DEFAULT_CURRENCY, normalizeCurrency };
+export { DEFAULT_CURRENCY, normalizeCurrency };

--- a/shared/collectionFilters.js
+++ b/shared/collectionFilters.js
@@ -7,14 +7,6 @@ export const COLLECTION_FILTER_KEYS = Object.freeze([
   'label'
 ]);
 
-export const DEFAULT_COLLECTION_FILTERS = Object.freeze({
-  search: '',
-  genre: '',
-  style: '',
-  decade: '',
-  format: '',
-  label: ''
-});
 
 function readFilterValue(source, key) {
   if (!source) {

--- a/shared/i18n.js
+++ b/shared/i18n.js
@@ -1,6 +1,6 @@
 export const LOCALE_STORAGE_KEY = 'discographic-locale';
-export const DEFAULT_LOCALE = 'es';
-export const SUPPORTED_LOCALES = ['es', 'en'];
+const DEFAULT_LOCALE = 'es';
+const SUPPORTED_LOCALES = ['es', 'en'];
 
 export const messages = {
   es: {
@@ -944,7 +944,7 @@ export function persistLocale(locale) {
   }
 }
 
-export function interpolate(template, vars = {}) {
+function interpolate(template, vars = {}) {
   return String(template).replace(/\{(\w+)\}/g, (_, key) => String(vars[key] ?? ''));
 }
 

--- a/src/lib/importSync.js
+++ b/src/lib/importSync.js
@@ -1,4 +1,4 @@
-export const IMPORT_TERMINAL_STATUSES = new Set(['completed', 'partial', 'failed', 'local_only']);
+const IMPORT_TERMINAL_STATUSES = new Set(['completed', 'partial', 'failed', 'local_only']);
 
 const IMPORT_RESULT_META = {
   completed: {

--- a/src/lib/releaseEdits.js
+++ b/src/lib/releaseEdits.js
@@ -1,4 +1,4 @@
-export function normalizeNoteText(value) {
+function normalizeNoteText(value) {
   return String(value || '').trim();
 }
 

--- a/src/lib/wallGrid.js
+++ b/src/lib/wallGrid.js
@@ -1,6 +1,6 @@
 export const WALL_GRID_GAP = 16;
 export const WALL_TITLE_PANEL_HEIGHT = 64;
-export const WALL_OVERSCAN_ROWS = 2;
+const WALL_OVERSCAN_ROWS = 2;
 
 export function filterWallReleases(releases, filters = {}) {
   const query = String(filters.search || '').trim().toLowerCase();


### PR DESCRIPTION
## Summary
- Remove the unused `getUserByUsername` database helper and unused collection filter defaults
- Make internal-only constants/helpers private to their modules
- Remove the unused `SUPPORTED_CURRENCIES` re-export from exchange rate services

## Test Plan
- [x] npx --yes knip --reporter json
- [x] npm test
- [x] npm run build