### PR TITLE
refactor: centralize shared API contracts

### DIFF
--- a/server/routes/account.js
+++ b/server/routes/account.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import { normalizeAccountResponse } from '../../shared/contracts/account.js';
 import { clearUserCollectionData, getDiscogsAccount, getSettingForUser, setSettingForUser, upsertDiscogsAccount } from '../db.js';
 import { requireAuth } from '../middleware/auth.js';
 import { normalizeCurrency } from '../../shared/currency.js';
@@ -16,12 +17,12 @@ function maskToken(token) {
 }
 
 function serializeAccount(account, userId) {
-  return {
+  return normalizeAccountResponse({
     discogsUsername: account?.discogs_username || '',
     tokenConfigured: Boolean(account?.discogs_token),
     tokenPreview: account?.discogs_token ? maskToken(account.discogs_token) : null,
     currency: normalizeCurrency(getSettingForUser(userId, 'currency', 'EUR'))
-  };
+  });
 }
 
 router.get('/', (req, res) => {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,21 +1,22 @@
 import bcrypt from 'bcryptjs';
 import express from 'express';
+import { normalizeAuthStatus, normalizeUser } from '../../shared/contracts/account.js';
 import { createUser, getUserAuthById, getUserAuthByUsername, getUserCount, getUserById, migrateLegacyDataToUser, updateUserPasswordHash } from '../db.js';
 import { getCurrentUser, requireAuth } from '../middleware/auth.js';
 
 const router = express.Router();
 
 function sanitizeUser(user) {
-  return user ? { id: user.id, username: user.username, role: user.role, created_at: user.created_at } : null;
+  return normalizeUser(user);
 }
 
 router.get('/status', (req, res) => {
   const user = getCurrentUser(req);
-  res.json({
+  res.json(normalizeAuthStatus({
     needsBootstrap: getUserCount() === 0,
     loggedIn: Boolean(user),
     user: sanitizeUser(user)
-  });
+  }));
 });
 
 router.post('/bootstrap', async (req, res) => {

--- a/server/routes/collection.js
+++ b/server/routes/collection.js
@@ -3,6 +3,12 @@ import db, { getSettingForUser, hydrateRelease, parseJson, stringifyJson } from 
 import { getDiscogsClientForUser, requireAuth } from '../middleware/auth.js';
 import { DEFAULT_CURRENCY, convertReleasePrices, normalizeCurrency } from '../services/exchangeRates.js';
 import { MARKETPLACE_STATUS } from '../../shared/contracts/marketplace.js';
+import {
+  normalizeCollectionRelease,
+  normalizeRandomRelease,
+  normalizeReleaseDetail,
+  normalizeWallRelease
+} from '../../shared/contracts/release.js';
 import { fetchMarketplaceValue } from '../services/marketplaceValue.js';
 import { parseStoredNotes, replaceNoteText, resolveNoteFieldId } from '../services/notes.js';
 import { buildReleaseFilterWhere, getCollectionFilterOptions } from '../services/releaseFilters.js';
@@ -44,17 +50,9 @@ function getDisplayCurrency(req) {
   return normalizeCurrency(req.query.currency || getSettingForUser(req.session.userId, 'currency', DEFAULT_CURRENCY));
 }
 
-async function convertHydratedRelease(req, release) {
-  return convertReleasePrices(hydrateRelease(release), getDisplayCurrency(req));
-}
-
-function attachCoverUrls(release) {
-  return {
-    ...release,
-    detail_cover_url: `/api/media/cover/${release.id}?variant=detail`,
-    wall_cover_url: `/api/media/cover/${release.id}?variant=wall`,
-    poster_cover_url: `/api/media/cover/${release.id}?variant=poster`
-  };
+async function convertHydratedRelease(req, release, normalizeRelease = normalizeCollectionRelease) {
+  const converted = await convertReleasePrices(hydrateRelease(release), getDisplayCurrency(req));
+  return normalizeRelease(converted);
 }
 
 async function enrichReleaseIfNeeded(req, release) {
@@ -66,7 +64,7 @@ async function enrichReleaseIfNeeded(req, release) {
   // tracklist stays '[]' until we call /releases/:id for the first time.
   const neverEnriched = !release.tracklist || release.tracklist === '[]';
   if (!neverEnriched) {
-    return convertHydratedRelease(req, release);
+    return convertHydratedRelease(req, release, normalizeReleaseDetail);
   }
 
   let discogs;
@@ -106,7 +104,7 @@ async function enrichReleaseIfNeeded(req, release) {
   );
 
   const fresh = db.prepare(`SELECT ${BASE_FIELDS} FROM releases WHERE id = ? AND user_id = ?`).get(release.id, req.session.userId);
-  return convertHydratedRelease(req, fresh);
+  return convertHydratedRelease(req, fresh, normalizeReleaseDetail);
 }
 
 router.get('/', async (req, res) => {
@@ -160,9 +158,9 @@ router.get('/random', async (req, res) => {
       return res.status(404).json({ error: 'No hay discos en la coleccion todavia' });
     }
 
-    const converted = await convertHydratedRelease(req, release);
+    const converted = await convertHydratedRelease(req, release, normalizeRandomRelease);
 
-    return res.json(attachCoverUrls(converted));
+    return res.json(converted);
   } catch (error) {
     return res.status(500).json({ error: error.message });
   }
@@ -175,7 +173,7 @@ router.get('/covers', (req, res) => {
       FROM releases
       WHERE user_id = ?
       ORDER BY date_added DESC, artist ASC, title ASC
-    `).all(req.session.userId).map((release) => attachCoverUrls(hydrateRelease(release)));
+    `).all(req.session.userId).map((release) => normalizeWallRelease(hydrateRelease(release)));
 
     return res.json({ releases, filters: getCollectionFilterOptions(db, req.session.userId) });
   } catch (error) {
@@ -192,7 +190,7 @@ router.get('/:id', async (req, res) => {
     }
 
     const hydrated = await enrichReleaseIfNeeded(req, release);
-    return res.json(attachCoverUrls(hydrated));
+    return res.json(hydrated);
   } catch (error) {
     return res.status(500).json({ error: error.message });
   }
@@ -247,8 +245,8 @@ router.put('/:id', async (req, res) => {
     `).run(nextRating, stringifyJson(nextNotes), req.params.id, req.session.userId);
 
     const updated = db.prepare(`SELECT ${BASE_FIELDS} FROM releases WHERE id = ? AND user_id = ?`).get(req.params.id, req.session.userId);
-    const converted = await convertHydratedRelease(req, updated);
-    return res.json(attachCoverUrls(converted));
+    const converted = await convertHydratedRelease(req, updated, normalizeReleaseDetail);
+    return res.json(converted);
   } catch (error) {
     return res.status(500).json({ error: error.message });
   }

--- a/shared/contracts/account.js
+++ b/shared/contracts/account.js
@@ -1,0 +1,154 @@
+import { DEFAULT_CURRENCY, normalizeCurrency } from '../currency.js';
+
+function asBoolean(value) {
+  return value === true || value === 1;
+}
+
+function asNumber(value, fallback = null) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function asText(value, fallback = '') {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asNullableText(value) {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text || null;
+}
+
+export function normalizeUser(user) {
+  if (!user || typeof user !== 'object') {
+    return null;
+  }
+
+  const id = asNumber(user.id);
+  if (id == null) {
+    return null;
+  }
+
+  return {
+    id,
+    username: asText(user.username),
+    role: asText(user.role, 'user') || 'user',
+    created_at: asNullableText(user.created_at)
+  };
+}
+
+export function normalizeAuthStatus(payload = {}) {
+  const user = normalizeUser(payload.user);
+  const loggedIn = asBoolean(payload.loggedIn) || Boolean(user);
+
+  return {
+    needsBootstrap: asBoolean(payload.needsBootstrap),
+    loggedIn,
+    user: loggedIn ? user : null
+  };
+}
+
+export function normalizeAccountResponse(payload = {}) {
+  return {
+    discogsUsername: asText(payload.discogsUsername).trim(),
+    tokenConfigured: asBoolean(payload.tokenConfigured),
+    tokenPreview: asNullableText(payload.tokenPreview),
+    currency: normalizeCurrency(payload.currency)
+  };
+}
+
+function buildCapabilities({ loggedIn, isAdmin, tokenConfigured, accountUnavailable }) {
+  const hasDiscogs = loggedIn && tokenConfigured === true && !accountUnavailable;
+  const canManageAccount = loggedIn && !accountUnavailable;
+
+  return {
+    canUseCollection: hasDiscogs,
+    canSyncDiscogs: hasDiscogs,
+    canImport: hasDiscogs,
+    canExport: hasDiscogs,
+    canManageAccount,
+    canAdminUsers: loggedIn && isAdmin
+  };
+}
+
+export function normalizeAccountState({ auth = {}, account = null, accountUnavailable = false } = {}) {
+  const authStatus = normalizeAuthStatus(auth);
+  const user = authStatus.user;
+  const loggedIn = authStatus.loggedIn;
+  const isAdmin = user?.role === 'admin';
+
+  if (!loggedIn) {
+    return {
+      needsBootstrap: authStatus.needsBootstrap,
+      loggedIn: false,
+      user: null,
+      isAdmin: false,
+      accountUnavailable: false,
+      discogs: {
+        username: null,
+        tokenConfigured: false,
+        tokenPreview: null
+      },
+      preferences: {
+        currency: DEFAULT_CURRENCY
+      },
+      capabilities: buildCapabilities({
+        loggedIn: false,
+        isAdmin: false,
+        tokenConfigured: false,
+        accountUnavailable: false
+      })
+    };
+  }
+
+  if (accountUnavailable) {
+    return {
+      needsBootstrap: authStatus.needsBootstrap,
+      loggedIn: true,
+      user,
+      isAdmin,
+      accountUnavailable: true,
+      discogs: {
+        username: null,
+        tokenConfigured: null,
+        tokenPreview: null
+      },
+      preferences: {
+        currency: DEFAULT_CURRENCY
+      },
+      capabilities: buildCapabilities({
+        loggedIn: true,
+        isAdmin,
+        tokenConfigured: null,
+        accountUnavailable: true
+      })
+    };
+  }
+
+  const accountState = normalizeAccountResponse(account || {});
+
+  return {
+    needsBootstrap: authStatus.needsBootstrap,
+    loggedIn: true,
+    user,
+    isAdmin,
+    accountUnavailable: false,
+    discogs: {
+      username: accountState.discogsUsername || null,
+      tokenConfigured: accountState.tokenConfigured,
+      tokenPreview: accountState.tokenPreview
+    },
+    preferences: {
+      currency: accountState.currency
+    },
+    capabilities: buildCapabilities({
+      loggedIn: true,
+      isAdmin,
+      tokenConfigured: accountState.tokenConfigured,
+      accountUnavailable: false
+    })
+  };
+}

--- a/shared/contracts/release.js
+++ b/shared/contracts/release.js
@@ -1,0 +1,178 @@
+import { MARKETPLACE_STATUS } from './marketplace.js';
+
+const LOCAL_COVER_VARIANTS = new Set(['detail', 'wall', 'poster']);
+const MARKETPLACE_STATUSES = new Set(Object.values(MARKETPLACE_STATUS));
+
+function asArray(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value !== 'string' || !value) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function asObject(value) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value !== 'string' || !value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function asNumber(value, fallback = null) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function asText(value, fallback = '') {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asNullableText(value) {
+  return typeof value === 'string' && value ? value : null;
+}
+
+function asMarketplaceStatus(value) {
+  return MARKETPLACE_STATUSES.has(value) ? value : MARKETPLACE_STATUS.PENDING;
+}
+
+function validRelease(release) {
+  return release?.id != null;
+}
+
+export function buildLocalCoverUrl(id, variant) {
+  const normalizedId = asNumber(id);
+  if (normalizedId == null || !LOCAL_COVER_VARIANTS.has(variant)) {
+    return null;
+  }
+
+  return `/api/media/cover/${normalizedId}?variant=${variant}`;
+}
+
+export function normalizeCollectionRelease(release = {}) {
+  const id = asNumber(release.id);
+
+  return {
+    id,
+    user_id: asNumber(release.user_id),
+    release_id: asNumber(release.release_id),
+    instance_id: asNumber(release.instance_id),
+    title: asText(release.title, '-'),
+    artist: asText(release.artist, '-'),
+    year: asNumber(release.year),
+    genres: asArray(release.genres),
+    styles: asArray(release.styles),
+    formats: asArray(release.formats),
+    labels: asArray(release.labels),
+    country: asNullableText(release.country),
+    cover_url: asNullableText(release.cover_url),
+    rating: asNumber(release.rating, 0),
+    notes: asArray(release.notes),
+    notes_text: asText(release.notes_text),
+    date_added: asNullableText(release.date_added),
+    estimated_value: asNumber(release.estimated_value),
+    marketplace_status: asMarketplaceStatus(release.marketplace_status),
+    listing_status: asNullableText(release.listing_status),
+    listing_price: asNumber(release.listing_price),
+    listing_currency: asNullableText(release.listing_currency),
+    listing_price_eur: asNumber(release.listing_price_eur),
+    folder_id: asNumber(release.folder_id, 0),
+    synced_at: asNullableText(release.synced_at),
+    display_currency: asNullableText(release.display_currency)
+  };
+}
+
+export function normalizeReleaseDetail(release = {}) {
+  const normalized = normalizeCollectionRelease(release);
+
+  return {
+    ...normalized,
+    tracklist: asArray(release.tracklist),
+    raw_json: asObject(release.raw_json),
+    detail_cover_url: buildLocalCoverUrl(normalized.id, 'detail'),
+    wall_cover_url: buildLocalCoverUrl(normalized.id, 'wall'),
+    poster_cover_url: buildLocalCoverUrl(normalized.id, 'poster')
+  };
+}
+
+export function normalizeRandomRelease(release = {}) {
+  return normalizeReleaseDetail(release);
+}
+
+export function normalizeWallRelease(release = {}) {
+  const id = asNumber(release.id);
+
+  return {
+    id,
+    release_id: asNumber(release.release_id),
+    title: asText(release.title, '-'),
+    artist: asText(release.artist, '-'),
+    year: asNumber(release.year),
+    genres: asArray(release.genres),
+    styles: asArray(release.styles),
+    formats: asArray(release.formats),
+    labels: asArray(release.labels),
+    cover_url: asNullableText(release.cover_url),
+    wall_cover_url: buildLocalCoverUrl(id, 'wall'),
+    poster_cover_url: buildLocalCoverUrl(id, 'poster')
+  };
+}
+
+function normalizePagination(pagination = {}, releaseCount = 0) {
+  return {
+    page: asNumber(pagination.page, 1),
+    limit: asNumber(pagination.limit, releaseCount),
+    total: asNumber(pagination.total, releaseCount),
+    totalPages: asNumber(pagination.totalPages, 1)
+  };
+}
+
+function normalizeFilters(filters) {
+  return filters && typeof filters === 'object' && !Array.isArray(filters) ? filters : {};
+}
+
+export function normalizeCollectionResponse(payload = {}) {
+  const releases = asArray(payload.releases)
+    .map(normalizeCollectionRelease)
+    .filter(validRelease);
+
+  return {
+    releases,
+    displayCurrency: asNullableText(payload.displayCurrency),
+    pagination: normalizePagination(payload.pagination, releases.length),
+    filters: normalizeFilters(payload.filters)
+  };
+}
+
+export function normalizeWallResponse(payload = {}) {
+  const releases = asArray(payload.releases)
+    .map(normalizeWallRelease)
+    .filter(validRelease);
+
+  return {
+    releases,
+    filters: normalizeFilters(payload.filters)
+  };
+}

--- a/src/lib/AuthContext.jsx
+++ b/src/lib/AuthContext.jsx
@@ -1,28 +1,22 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { api } from './api';
-import { DEFAULT_CURRENCY } from '../../shared/currency';
+import { normalizeAccountState, normalizeAuthStatus } from '../../shared/contracts/account';
 
 const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
   const [loading, setLoading] = useState(true);
-  const [needsBootstrap, setNeedsBootstrap] = useState(false);
-  const [user, setUser] = useState(null);
-  const [discogsConfigured, setDiscogsConfigured] = useState(false);
-  const [accountUnavailable, setAccountUnavailable] = useState(false);
-  const [currency, setCurrency] = useState(DEFAULT_CURRENCY);
+  const [accountState, setAccountState] = useState(() => normalizeAccountState());
 
-  async function refreshAccountState() {
+  async function refreshAccountState(auth = accountState) {
     try {
       const account = await api.getAccount();
-      setDiscogsConfigured(Boolean(account.tokenConfigured));
-      setCurrency(account.currency || DEFAULT_CURRENCY);
-      setAccountUnavailable(false);
-      return account;
+      const nextState = normalizeAccountState({ auth, account });
+      setAccountState(nextState);
+      return nextState;
     } catch (error) {
-      setDiscogsConfigured(false);
-      setCurrency(DEFAULT_CURRENCY);
-      setAccountUnavailable(true);
+      const nextState = normalizeAccountState({ auth, accountUnavailable: true });
+      setAccountState(nextState);
       throw error;
     }
   }
@@ -31,21 +25,14 @@ export function AuthProvider({ children }) {
     setLoading(true);
     try {
       const status = await api.getAuthStatus();
-      setNeedsBootstrap(status.needsBootstrap);
-      setUser(status.user || null);
 
       if (status.loggedIn) {
-        await refreshAccountState().catch(() => null);
+        await refreshAccountState(status).catch(() => null);
       } else {
-        setDiscogsConfigured(false);
-        setAccountUnavailable(false);
-        setCurrency(DEFAULT_CURRENCY);
+        setAccountState(normalizeAccountState({ auth: status }));
       }
     } catch {
-      setUser(null);
-      setDiscogsConfigured(false);
-      setAccountUnavailable(false);
-      setCurrency(DEFAULT_CURRENCY);
+      setAccountState(normalizeAccountState());
     } finally {
       setLoading(false);
     }
@@ -57,28 +44,28 @@ export function AuthProvider({ children }) {
 
   const value = useMemo(() => ({
     loading,
-    needsBootstrap,
-    user,
-    loggedIn: Boolean(user),
-    isAdmin: user?.role === 'admin',
-    discogsConfigured,
-    accountUnavailable,
-    currency,
+    accountState,
+    capabilities: accountState.capabilities,
+    needsBootstrap: accountState.needsBootstrap,
+    user: accountState.user,
+    loggedIn: accountState.loggedIn,
+    isAdmin: accountState.isAdmin,
+    discogsConfigured: accountState.discogs.tokenConfigured === true,
+    accountUnavailable: accountState.accountUnavailable,
+    currency: accountState.preferences.currency,
     async login(username, password) {
       const result = await api.login({ username, password });
-      setNeedsBootstrap(false);
-      setUser(result.user);
+      const auth = normalizeAuthStatus({ needsBootstrap: false, loggedIn: true, user: result.user });
+      setAccountState(normalizeAccountState({ auth }));
       setLoading(false);
-      await refreshAccountState().catch(() => null);
+      await refreshAccountState(auth).catch(() => null);
       return result;
     },
     async bootstrap(username, password) {
       const result = await api.bootstrap({ username, password });
-      setNeedsBootstrap(false);
-      setUser(result.user);
+      const auth = normalizeAuthStatus({ needsBootstrap: false, loggedIn: true, user: result.user });
+      setAccountState(normalizeAccountState({ auth, account: { tokenConfigured: false } }));
       setLoading(false);
-      setDiscogsConfigured(false);
-      setAccountUnavailable(false);
       return result;
     },
     async logout() {
@@ -90,11 +77,20 @@ export function AuthProvider({ children }) {
     },
     async setCurrencyPreference(nextCurrency) {
       await api.setPreference('currency', nextCurrency);
-      setCurrency(nextCurrency);
-      return nextCurrency;
+      const nextState = normalizeAccountState({
+        auth: accountState,
+        account: {
+          discogsUsername: accountState.discogs.username || '',
+          tokenConfigured: accountState.discogs.tokenConfigured === true,
+          tokenPreview: accountState.discogs.tokenPreview,
+          currency: nextCurrency
+        }
+      });
+      setAccountState(nextState);
+      return nextState.preferences.currency;
     },
     refresh
-  }), [loading, needsBootstrap, user, discogsConfigured, accountUnavailable, currency]);
+  }), [loading, accountState]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,5 +1,12 @@
 import { LOCALE_STORAGE_KEY, resolveLocale, translate } from '../../shared/i18n.js';
+import { normalizeAccountResponse, normalizeAuthStatus } from '../../shared/contracts/account.js';
 import { normalizeDashboardStats } from '../../shared/contracts/dashboardStats.js';
+import {
+  normalizeCollectionResponse,
+  normalizeRandomRelease,
+  normalizeReleaseDetail,
+  normalizeWallResponse
+} from '../../shared/contracts/release.js';
 
 const API_BASE = '/api';
 
@@ -39,13 +46,13 @@ async function request(path, options = {}) {
 }
 
 export const api = {
-  getAuthStatus: () => request('/auth/status'),
+  getAuthStatus: async () => normalizeAuthStatus(await request('/auth/status')),
   bootstrap: (payload) => request('/auth/bootstrap', { method: 'POST', body: JSON.stringify(payload) }),
   login: (payload) => request('/auth/login', { method: 'POST', body: JSON.stringify(payload) }),
   logout: () => request('/auth/logout', { method: 'POST' }),
   getMe: () => request('/auth/me'),
   changePassword: (payload) => request('/auth/change-password', { method: 'POST', body: JSON.stringify(payload) }),
-  getAccount: () => request('/account'),
+  getAccount: async () => normalizeAccountResponse(await request('/account')),
   updateAccount: (payload) => request('/account', { method: 'PUT', body: JSON.stringify(payload) }),
   resetCollection: () => request('/account/reset', { method: 'POST' }),
   getPreference: (key) => request(`/account/preferences/${encodeURIComponent(key)}`),
@@ -54,14 +61,14 @@ export const api = {
     body: JSON.stringify({ value })
   }),
   getStats: async () => normalizeDashboardStats(await request('/stats')),
-  getCollection: (params = {}) => request(`/collection?${new URLSearchParams(params).toString()}`),
-  getCollectionCovers: () => request('/collection/covers'),
-  getRandomRelease: () => request('/collection/random'),
-  getRelease: (id) => request(`/collection/${id}`),
-  updateRelease: (id, payload) => request(`/collection/${id}`, {
+  getCollection: async (params = {}) => normalizeCollectionResponse(await request(`/collection?${new URLSearchParams(params).toString()}`)),
+  getCollectionCovers: async () => normalizeWallResponse(await request('/collection/covers')),
+  getRandomRelease: async () => normalizeRandomRelease(await request('/collection/random')),
+  getRelease: async (id) => normalizeReleaseDetail(await request(`/collection/${id}`)),
+  updateRelease: async (id, payload) => normalizeReleaseDetail(await request(`/collection/${id}`, {
     method: 'PUT',
     body: JSON.stringify(payload)
-  }),
+  })),
   startSync: () => request('/sync', { method: 'POST' }),
   enrichValues: () => request('/sync/enrich', { method: 'POST' }),
   stopEnrich: () => request('/sync/enrich/stop', { method: 'POST' }),

--- a/tests/account-contract.test.js
+++ b/tests/account-contract.test.js
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeAccountResponse,
+  normalizeAccountState,
+  normalizeAuthStatus
+} from '../shared/contracts/account.js';
+import { DEFAULT_CURRENCY } from '../shared/currency.js';
+
+const user = {
+  id: '3',
+  username: 'collector',
+  role: 'admin',
+  created_at: '2026-04-20T08:00:00.000Z'
+};
+
+describe('account contract', () => {
+  it('normalizes logged-out account state with no collection capabilities', () => {
+    const state = normalizeAccountState({
+      auth: { needsBootstrap: true, loggedIn: false, user: null }
+    });
+
+    expect(state).toEqual({
+      needsBootstrap: true,
+      loggedIn: false,
+      user: null,
+      isAdmin: false,
+      accountUnavailable: false,
+      discogs: {
+        username: null,
+        tokenConfigured: false,
+        tokenPreview: null
+      },
+      preferences: {
+        currency: DEFAULT_CURRENCY
+      },
+      capabilities: {
+        canUseCollection: false,
+        canSyncDiscogs: false,
+        canImport: false,
+        canExport: false,
+        canManageAccount: false,
+        canAdminUsers: false
+      }
+    });
+  });
+
+  it('normalizes a logged-in user without Discogs configuration', () => {
+    const state = normalizeAccountState({
+      auth: { needsBootstrap: false, loggedIn: true, user },
+      account: { discogsUsername: '', tokenConfigured: false, tokenPreview: null, currency: 'usd' }
+    });
+
+    expect(state.user).toEqual({
+      id: 3,
+      username: 'collector',
+      role: 'admin',
+      created_at: '2026-04-20T08:00:00.000Z'
+    });
+    expect(state.isAdmin).toBe(true);
+    expect(state.discogs.tokenConfigured).toBe(false);
+    expect(state.preferences.currency).toBe('USD');
+    expect(state.capabilities.canManageAccount).toBe(true);
+    expect(state.capabilities.canUseCollection).toBe(false);
+    expect(state.capabilities.canAdminUsers).toBe(true);
+  });
+
+  it('normalizes a logged-in user with Discogs configuration and enabled workflows', () => {
+    const state = normalizeAccountState({
+      auth: { needsBootstrap: false, loggedIn: true, user: { ...user, role: 'user' } },
+      account: { discogsUsername: 'miles', tokenConfigured: true, tokenPreview: 'abcd...wxyz', currency: 'GBP' }
+    });
+
+    expect(state.discogs).toEqual({
+      username: 'miles',
+      tokenConfigured: true,
+      tokenPreview: 'abcd...wxyz'
+    });
+    expect(state.preferences.currency).toBe('GBP');
+    expect(state.capabilities).toEqual({
+      canUseCollection: true,
+      canSyncDiscogs: true,
+      canImport: true,
+      canExport: true,
+      canManageAccount: true,
+      canAdminUsers: false
+    });
+  });
+
+  it('keeps Discogs facts unknown when the account endpoint is unavailable', () => {
+    const state = normalizeAccountState({
+      auth: { needsBootstrap: false, loggedIn: true, user },
+      accountUnavailable: true
+    });
+
+    expect(state.accountUnavailable).toBe(true);
+    expect(state.discogs).toEqual({
+      username: null,
+      tokenConfigured: null,
+      tokenPreview: null
+    });
+    expect(state.preferences.currency).toBe(DEFAULT_CURRENCY);
+    expect(state.capabilities.canUseCollection).toBe(false);
+    expect(state.capabilities.canManageAccount).toBe(false);
+  });
+
+  it('normalizes existing auth and account endpoint payloads independently', () => {
+    expect(normalizeAuthStatus({ needsBootstrap: 0, loggedIn: 1, user })).toMatchObject({
+      needsBootstrap: false,
+      loggedIn: true,
+      user: { id: 3, username: 'collector' }
+    });
+
+    expect(normalizeAccountResponse({
+      discogsUsername: ' miles ',
+      tokenConfigured: 1,
+      tokenPreview: 'abcd...wxyz',
+      currency: 'gbp'
+    })).toEqual({
+      discogsUsername: 'miles',
+      tokenConfigured: true,
+      tokenPreview: 'abcd...wxyz',
+      currency: 'GBP'
+    });
+  });
+});

--- a/tests/release-contract.test.js
+++ b/tests/release-contract.test.js
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildLocalCoverUrl,
+  normalizeCollectionRelease,
+  normalizeCollectionResponse,
+  normalizeReleaseDetail,
+  normalizeWallRelease,
+  normalizeWallResponse
+} from '../shared/contracts/release.js';
+import { MARKETPLACE_STATUS } from '../shared/contracts/marketplace.js';
+
+const storedRelease = {
+  id: '7',
+  user_id: 9,
+  release_id: '1234',
+  instance_id: '55',
+  title: 'Kind of Blue',
+  artist: 'Miles Davis',
+  year: '1959',
+  genres: '["Jazz","Modal"]',
+  styles: 'not-json',
+  formats: '[{"name":"Vinyl","qty":"1"}]',
+  labels: '[{"name":"Columbia"}]',
+  country: 'US',
+  cover_url: '',
+  rating: '4',
+  notes: [{ field_id: 1, value: 'First press' }],
+  notes_text: 'First press',
+  date_added: '2026-04-01',
+  estimated_value: '28.5',
+  marketplace_status: MARKETPLACE_STATUS.PRICED,
+  listing_status: 'For Sale',
+  listing_price: '35.2',
+  listing_currency: 'USD',
+  listing_price_eur: '32.1',
+  tracklist: '[{"position":"A1","title":"So What"}]',
+  folder_id: '2',
+  raw_json: '{"community":{"have":5}}',
+  synced_at: '2026-04-02T10:00:00.000Z',
+  display_currency: 'USD'
+};
+
+describe('release contract', () => {
+  it('normalizes stored collection rows into the shared release shape', () => {
+    expect(normalizeCollectionRelease(storedRelease)).toEqual({
+      id: 7,
+      user_id: 9,
+      release_id: 1234,
+      instance_id: 55,
+      title: 'Kind of Blue',
+      artist: 'Miles Davis',
+      year: 1959,
+      genres: ['Jazz', 'Modal'],
+      styles: [],
+      formats: [{ name: 'Vinyl', qty: '1' }],
+      labels: [{ name: 'Columbia' }],
+      country: 'US',
+      cover_url: null,
+      rating: 4,
+      notes: [{ field_id: 1, value: 'First press' }],
+      notes_text: 'First press',
+      date_added: '2026-04-01',
+      estimated_value: 28.5,
+      marketplace_status: MARKETPLACE_STATUS.PRICED,
+      listing_status: 'For Sale',
+      listing_price: 35.2,
+      listing_currency: 'USD',
+      listing_price_eur: 32.1,
+      folder_id: 2,
+      synced_at: '2026-04-02T10:00:00.000Z',
+      display_currency: 'USD'
+    });
+  });
+
+  it('builds detail release cover URLs without fetching cover files', () => {
+    const detail = normalizeReleaseDetail(storedRelease);
+
+    expect(buildLocalCoverUrl(7, 'detail')).toBe('/api/media/cover/7?variant=detail');
+    expect(detail.detail_cover_url).toBe('/api/media/cover/7?variant=detail');
+    expect(detail.wall_cover_url).toBe('/api/media/cover/7?variant=wall');
+    expect(detail.poster_cover_url).toBe('/api/media/cover/7?variant=poster');
+    expect(detail.tracklist).toEqual([{ position: 'A1', title: 'So What' }]);
+    expect(detail.raw_json).toEqual({ community: { have: 5 } });
+  });
+
+  it('uses an explicit wall release representation', () => {
+    expect(normalizeWallRelease(storedRelease)).toEqual({
+      id: 7,
+      release_id: 1234,
+      title: 'Kind of Blue',
+      artist: 'Miles Davis',
+      year: 1959,
+      genres: ['Jazz', 'Modal'],
+      styles: [],
+      formats: [{ name: 'Vinyl', qty: '1' }],
+      labels: [{ name: 'Columbia' }],
+      cover_url: null,
+      wall_cover_url: '/api/media/cover/7?variant=wall',
+      poster_cover_url: '/api/media/cover/7?variant=poster'
+    });
+  });
+
+  it('normalizes collection and wall API payloads for client consumers', () => {
+    const collection = normalizeCollectionResponse({
+      releases: [storedRelease, { id: null }],
+      displayCurrency: 'USD',
+      pagination: { page: '2', limit: '25', total: '51', totalPages: '3' },
+      filters: { genres: ['Jazz'] }
+    });
+
+    expect(collection.releases).toHaveLength(1);
+    expect(collection.displayCurrency).toBe('USD');
+    expect(collection.pagination).toEqual({ page: 2, limit: 25, total: 51, totalPages: 3 });
+    expect(collection.filters).toEqual({ genres: ['Jazz'] });
+
+    const wall = normalizeWallResponse({ releases: [storedRelease], filters: { styles: ['Modal'] } });
+    expect(wall.releases[0].wall_cover_url).toBe('/api/media/cover/7?variant=wall');
+    expect(wall.filters).toEqual({ styles: ['Modal'] });
+  });
+});


### PR DESCRIPTION
## Summary
- Add shared Release shape contract for collection, detail, random, and wall representations
- Add shared Account state contract with computed workflow capabilities and unknown-account handling
- Wire collection routes, auth/account routes, AuthContext, and API helpers through the shared contracts

## Test Plan
- npm test
- npm run build