### PR TITLE
refactor: centralize sync status contract

### DIFF
--- a/server/routes/import.js
+++ b/server/routes/import.js
@@ -14,6 +14,7 @@ import {
 } from '../services/importSync.js';
 import { notesToText, parseStoredNotes, replaceNoteText, resolveNoteFieldId } from '../services/notes.js';
 import { translate } from '../../shared/i18n.js';
+import { normalizeImportSyncState } from '../../shared/contracts/syncStatus.js';
 
 const router = express.Router();
 const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 5 * 1024 * 1024 } });
@@ -420,7 +421,7 @@ router.post('/apply', async (req, res) => {
         t: req.t
       });
       setImportSyncState(userId, syncState);
-      return res.json({ ok: true, applied: changes.length, syncState });
+      return res.json({ ok: true, applied: changes.length, syncState: normalizeImportSyncState(syncState) });
     }
 
     const syncState = createRunningImportSyncState({
@@ -432,7 +433,7 @@ router.post('/apply', async (req, res) => {
       t: req.t
     });
     setImportSyncState(userId, syncState);
-    res.json({ ok: true, applied: changes.length, syncState });
+    res.json({ ok: true, applied: changes.length, syncState: normalizeImportSyncState(syncState) });
 
     // Background sync with Discogs
     void syncChangesWithDiscogs({ userId, changes, discogs, locale: req.locale });
@@ -442,7 +443,7 @@ router.post('/apply', async (req, res) => {
 });
 
 router.get('/status', (req, res) => {
-  res.json(getImportSyncState(req.session.userId, req.locale));
+  res.json(normalizeImportSyncState(getImportSyncState(req.session.userId, req.locale)));
 });
 
 export default router;

--- a/server/routes/sync.js
+++ b/server/routes/sync.js
@@ -7,6 +7,7 @@ import { DEFAULT_CURRENCY, convertAmountWithRates, getExchangeSnapshot } from '.
 import { pruneUnseenReleases } from '../services/collectionReconcile.js';
 import { ENRICH_CONDITION, getPendingEnrichmentCount, getPendingEnrichmentRows } from '../services/enrichmentQueue.js';
 import { MARKETPLACE_STATUS } from '../../shared/contracts/marketplace.js';
+import { normalizeSyncStatus } from '../../shared/contracts/syncStatus.js';
 import { fetchMarketplaceValue } from '../services/marketplaceValue.js';
 
 const router = express.Router();
@@ -538,14 +539,15 @@ router.get('/status', (req, res) => {
     `SELECT COUNT(*) AS count FROM releases WHERE user_id = ? AND (${ENRICH_CONDITION})`
   ).get(req.session.userId).count;
 
-  res.json({
+  res.json(normalizeSyncStatus({
     ...state,
     enrichment: {
       ...state.enrichment,
       pending
     },
-    thumbnails: state.thumbnails
-  });
+    thumbnails: state.thumbnails,
+    inventory: state.inventory
+  }));
 });
 
 export default router;

--- a/shared/contracts/syncStatus.js
+++ b/shared/contracts/syncStatus.js
@@ -1,0 +1,182 @@
+export const SYNC_STATUS = Object.freeze({
+  IDLE: 'idle',
+  RUNNING: 'running',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+  STALLED: 'stalled'
+});
+
+export const IMPORT_SYNC_STATUS = Object.freeze({
+  IDLE: 'idle',
+  RUNNING: 'running',
+  COMPLETED: 'completed',
+  PARTIAL: 'partial',
+  FAILED: 'failed',
+  LOCAL_ONLY: 'local_only'
+});
+
+const SYNC_STATUSES = new Set(Object.values(SYNC_STATUS));
+const TERMINAL_SYNC_STATUSES = new Set([SYNC_STATUS.COMPLETED, SYNC_STATUS.FAILED]);
+const IMPORT_STATUSES = new Set(Object.values(IMPORT_SYNC_STATUS));
+const IMPORT_TERMINAL_STATUSES = new Set([
+  IMPORT_SYNC_STATUS.COMPLETED,
+  IMPORT_SYNC_STATUS.PARTIAL,
+  IMPORT_SYNC_STATUS.FAILED,
+  IMPORT_SYNC_STATUS.LOCAL_ONLY
+]);
+
+const IMPORT_RESULT_META = {
+  [IMPORT_SYNC_STATUS.COMPLETED]: {
+    tone: 'success',
+    titleKey: 'collection.importCompletedTitle',
+    helpKey: null
+  },
+  [IMPORT_SYNC_STATUS.PARTIAL]: {
+    tone: 'warning',
+    titleKey: 'collection.importPartialTitle',
+    helpKey: 'collection.importPartialHelp'
+  },
+  [IMPORT_SYNC_STATUS.LOCAL_ONLY]: {
+    tone: 'warning',
+    titleKey: 'collection.importLocalOnlyTitle',
+    helpKey: 'collection.importLocalOnlyHelp'
+  },
+  [IMPORT_SYNC_STATUS.FAILED]: {
+    tone: 'error',
+    titleKey: 'collection.importFailedTitle',
+    helpKey: 'collection.importFailedHelp'
+  }
+};
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function asNumber(value, fallback = 0) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function asText(value, fallback = '') {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asNullableText(value) {
+  return typeof value === 'string' && value ? value : null;
+}
+
+function progressPercent(current, total) {
+  if (!total) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, Math.round((current / total) * 100)));
+}
+
+function normalizeWorkflowStatus(value, fallback = SYNC_STATUS.IDLE) {
+  return SYNC_STATUSES.has(value) ? value : fallback;
+}
+
+function normalizeImportStatus(value) {
+  return IMPORT_STATUSES.has(value) ? value : IMPORT_SYNC_STATUS.IDLE;
+}
+
+function normalizeProgressWorkflow(workflow = {}, { withPending = false } = {}) {
+  const current = asNumber(workflow?.current);
+  const total = asNumber(workflow?.total);
+  const normalized = {
+    status: normalizeWorkflowStatus(workflow?.status),
+    current,
+    total,
+    progressPercent: progressPercent(current, total),
+    message: asText(workflow?.message)
+  };
+
+  if (withPending) {
+    normalized.pending = asNumber(workflow?.pending);
+  }
+
+  return normalized;
+}
+
+function normalizeImportFailure(failure) {
+  if (!failure || typeof failure !== 'object') {
+    return null;
+  }
+
+  return {
+    dbId: asNumber(failure.dbId, null),
+    releaseId: asNumber(failure.releaseId, null),
+    instanceId: asNumber(failure.instanceId, null),
+    artist: asText(failure.artist),
+    title: asText(failure.title),
+    reason: asText(failure.reason)
+  };
+}
+
+export function normalizeSyncStatus(payload = {}) {
+  const status = normalizeWorkflowStatus(payload?.status);
+  const current = asNumber(payload?.current);
+  const total = asNumber(payload?.total);
+
+  return {
+    locale: asText(payload?.locale, 'es') || 'es',
+    status,
+    phase: asText(payload?.phase, status === SYNC_STATUS.FAILED ? 'error' : SYNC_STATUS.IDLE),
+    current,
+    total,
+    progressPercent: progressPercent(current, total),
+    message: asText(payload?.message),
+    startedAt: asNullableText(payload?.startedAt),
+    finishedAt: asNullableText(payload?.finishedAt),
+    recordsSynced: asNumber(payload?.recordsSynced),
+    isRunning: status === SYNC_STATUS.RUNNING,
+    isTerminal: TERMINAL_SYNC_STATUSES.has(status),
+    enrichment: normalizeProgressWorkflow(payload?.enrichment, { withPending: true }),
+    thumbnails: normalizeProgressWorkflow(payload?.thumbnails),
+    inventory: normalizeProgressWorkflow(payload?.inventory)
+  };
+}
+
+export function normalizeImportSyncState(payload = {}) {
+  const status = normalizeImportStatus(payload?.status);
+  const current = asNumber(payload?.current);
+  const total = asNumber(payload?.total);
+  const failures = asArray(payload?.failures)
+    .map(normalizeImportFailure)
+    .filter(Boolean);
+
+  return {
+    locale: asText(payload?.locale, 'es') || 'es',
+    status,
+    current,
+    total,
+    applied: asNumber(payload?.applied, total),
+    synced: asNumber(payload?.synced),
+    failed: asNumber(payload?.failed, failures.length),
+    failures,
+    progressPercent: progressPercent(current, total),
+    isTerminal: isTerminalImportStatus(status),
+    message: asText(payload?.message)
+  };
+}
+
+export function isTerminalImportStatus(status) {
+  return IMPORT_TERMINAL_STATUSES.has(status);
+}
+
+export function getImportResultTone(status) {
+  return IMPORT_RESULT_META[status]?.tone || 'neutral';
+}
+
+export function getImportResultTitleKey(status) {
+  return IMPORT_RESULT_META[status]?.titleKey || 'collection.done';
+}
+
+export function getImportResultHelpKey(status) {
+  return IMPORT_RESULT_META[status]?.helpKey || null;
+}

--- a/src/components/ImportButton.jsx
+++ b/src/components/ImportButton.jsx
@@ -140,9 +140,7 @@ function ImportButton({ disabled = false }) {
     void poll();
   }
 
-  const syncProgress = syncState?.total
-    ? Math.min(100, Math.round((syncState.current / syncState.total) * 100))
-    : 0;
+  const syncProgress = syncState?.progressPercent || 0;
   const resultTone = getImportResultTone(syncState?.status);
   const resultTitleKey = getImportResultTitleKey(syncState?.status);
   const resultHelpKey = getImportResultHelpKey(syncState?.status);

--- a/src/components/SyncButton.jsx
+++ b/src/components/SyncButton.jsx
@@ -20,13 +20,13 @@ function SyncButton({ onSyncComplete, disabled = false }) {
   const enrichPollTimer = useRef(null);
   const syncPollFailures = useRef(0);
   const enrichPollFailures = useRef(0);
-  const syncing = status?.status === 'running';
+  const syncing = status?.isRunning || false;
   const pendingValues = status?.enrichment?.pending || 0;
   const thumbsRunning = status?.thumbnails?.status === 'running';
 
   const progress = useMemo(() => {
-    if (!syncing || !status?.total) return 0;
-    return Math.min(100, Math.round((status.current / status.total) * 100));
+    if (!syncing) return 0;
+    return status?.progressPercent || 0;
   }, [status, syncing]);
 
   const onSyncCompleteRef = useRef(onSyncComplete);
@@ -127,8 +127,8 @@ function SyncButton({ onSyncComplete, disabled = false }) {
   const enrichRunning = enrichStatus === 'running';
 
   const enrichProgress = useMemo(() => {
-    if (!enrichRunning || !status?.enrichment?.total) return 0;
-    return Math.min(100, Math.round((status.enrichment.current / status.enrichment.total) * 100));
+    if (!enrichRunning) return 0;
+    return status?.enrichment?.progressPercent || 0;
   }, [status, enrichRunning]);
 
   const pollEnrich = useCallback(async () => {
@@ -274,7 +274,7 @@ function SyncButton({ onSyncComplete, disabled = false }) {
             <span className="text-xs text-slate-500">{t('sync.mosaicPoster')}</span>
           </div>
           <div className="h-2 overflow-hidden rounded-full bg-slate-900/80">
-            <div className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-sky-400 transition-all duration-500" style={{ width: `${status.thumbnails.total ? Math.round((status.thumbnails.current / status.thumbnails.total) * 100) : 0}%` }} />
+            <div className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-sky-400 transition-all duration-500" style={{ width: `${status.thumbnails.progressPercent}%` }} />
           </div>
         </div>
       ) : null}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -7,6 +7,7 @@ import {
   normalizeReleaseDetail,
   normalizeWallResponse
 } from '../../shared/contracts/release.js';
+import { normalizeImportSyncState, normalizeSyncStatus } from '../../shared/contracts/syncStatus.js';
 
 const API_BASE = '/api';
 
@@ -72,7 +73,7 @@ export const api = {
   startSync: () => request('/sync', { method: 'POST' }),
   enrichValues: () => request('/sync/enrich', { method: 'POST' }),
   stopEnrich: () => request('/sync/enrich/stop', { method: 'POST' }),
-  getSyncStatus: () => request('/sync/status'),
+  getSyncStatus: async () => normalizeSyncStatus(await request('/sync/status')),
   listUsers: () => request('/admin/users'),
   createUser: (payload) => request('/admin/users', { method: 'POST', body: JSON.stringify(payload) }),
   deleteUser: (id) => request(`/admin/users/${id}`, { method: 'DELETE' }),
@@ -82,8 +83,14 @@ export const api = {
     form.append('file', file);
     return request('/import/preview', { method: 'POST', body: form });
   },
-  importApply: (previewId) => request('/import/apply', { method: 'POST', body: JSON.stringify({ previewId }) }),
-  getImportStatus: () => request('/import/status'),
+  importApply: async (previewId) => {
+    const result = await request('/import/apply', { method: 'POST', body: JSON.stringify({ previewId }) });
+    return {
+      ...result,
+      syncState: result.syncState ? normalizeImportSyncState(result.syncState) : null
+    };
+  },
+  getImportStatus: async () => normalizeImportSyncState(await request('/import/status')),
   downloadImportTemplate: () => {
     const locale = getLocaleHeader();
     const query = new URLSearchParams({ locale }).toString();

--- a/src/lib/importSync.js
+++ b/src/lib/importSync.js
@@ -1,40 +1,6 @@
-const IMPORT_TERMINAL_STATUSES = new Set(['completed', 'partial', 'failed', 'local_only']);
-
-const IMPORT_RESULT_META = {
-  completed: {
-    tone: 'success',
-    titleKey: 'collection.importCompletedTitle',
-    helpKey: null
-  },
-  partial: {
-    tone: 'warning',
-    titleKey: 'collection.importPartialTitle',
-    helpKey: 'collection.importPartialHelp'
-  },
-  local_only: {
-    tone: 'warning',
-    titleKey: 'collection.importLocalOnlyTitle',
-    helpKey: 'collection.importLocalOnlyHelp'
-  },
-  failed: {
-    tone: 'error',
-    titleKey: 'collection.importFailedTitle',
-    helpKey: 'collection.importFailedHelp'
-  }
-};
-
-export function isTerminalImportStatus(status) {
-  return IMPORT_TERMINAL_STATUSES.has(status);
-}
-
-export function getImportResultTone(status) {
-  return IMPORT_RESULT_META[status]?.tone || 'neutral';
-}
-
-export function getImportResultTitleKey(status) {
-  return IMPORT_RESULT_META[status]?.titleKey || 'collection.done';
-}
-
-export function getImportResultHelpKey(status) {
-  return IMPORT_RESULT_META[status]?.helpKey || null;
-}
+export {
+  getImportResultHelpKey,
+  getImportResultTitleKey,
+  getImportResultTone,
+  isTerminalImportStatus
+} from '../../shared/contracts/syncStatus.js';

--- a/tests/sync-status-contract.test.js
+++ b/tests/sync-status-contract.test.js
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getImportResultHelpKey,
+  getImportResultTitleKey,
+  getImportResultTone,
+  isTerminalImportStatus,
+  normalizeImportSyncState,
+  normalizeSyncStatus
+} from '../shared/contracts/syncStatus.js';
+
+describe('sync status contract', () => {
+  it('normalizes idle sync status with nested workflow defaults', () => {
+    expect(normalizeSyncStatus()).toEqual({
+      locale: 'es',
+      status: 'idle',
+      phase: 'idle',
+      current: 0,
+      total: 0,
+      progressPercent: 0,
+      message: '',
+      startedAt: null,
+      finishedAt: null,
+      recordsSynced: 0,
+      isRunning: false,
+      isTerminal: false,
+      enrichment: {
+        status: 'idle',
+        current: 0,
+        total: 0,
+        pending: 0,
+        progressPercent: 0,
+        message: ''
+      },
+      thumbnails: {
+        status: 'idle',
+        current: 0,
+        total: 0,
+        progressPercent: 0,
+        message: ''
+      },
+      inventory: {
+        status: 'idle',
+        current: 0,
+        total: 0,
+        progressPercent: 0,
+        message: ''
+      }
+    });
+  });
+
+  it('normalizes running sync, enrichment, thumbnails, and inventory state', () => {
+    const state = normalizeSyncStatus({
+      locale: 'en',
+      status: 'running',
+      phase: 'downloading',
+      current: '25',
+      total: '100',
+      message: 'Downloading collection',
+      startedAt: '2026-04-30T10:00:00.000Z',
+      recordsSynced: '20',
+      enrichment: {
+        status: 'running',
+        current: '5',
+        total: '10',
+        pending: '8',
+        message: 'Enriching 5/10'
+      },
+      thumbnails: {
+        status: 'completed',
+        current: '3',
+        total: '3',
+        message: 'Covers ready'
+      },
+      inventory: {
+        status: 'failed',
+        message: 'Inventory unavailable'
+      }
+    });
+
+    expect(state.status).toBe('running');
+    expect(state.progressPercent).toBe(25);
+    expect(state.isRunning).toBe(true);
+    expect(state.isTerminal).toBe(false);
+    expect(state.enrichment).toMatchObject({ status: 'running', pending: 8, progressPercent: 50 });
+    expect(state.thumbnails).toMatchObject({ status: 'completed', progressPercent: 100 });
+    expect(state.inventory).toMatchObject({ status: 'failed', message: 'Inventory unavailable' });
+  });
+
+  it('keeps completed, failed, and stalled sync statuses distinct', () => {
+    expect(normalizeSyncStatus({ status: 'completed', current: 3, total: 3 }).isTerminal).toBe(true);
+    expect(normalizeSyncStatus({ status: 'failed', message: 'boom' })).toMatchObject({
+      status: 'failed',
+      phase: 'error',
+      isTerminal: true,
+      message: 'boom'
+    });
+    expect(normalizeSyncStatus({ status: 'stalled', phase: 'downloading' })).toMatchObject({
+      status: 'stalled',
+      phase: 'downloading',
+      isRunning: false,
+      isTerminal: false
+    });
+  });
+});
+
+describe('import sync status contract', () => {
+  it('normalizes running import progress and failure details', () => {
+    const state = normalizeImportSyncState({
+      locale: 'en',
+      status: 'running',
+      current: '2',
+      total: '4',
+      applied: '4',
+      synced: '1',
+      failed: '1',
+      failures: [
+        {
+          dbId: '7',
+          releaseId: '123',
+          instanceId: '456',
+          artist: 'Artist',
+          title: 'Title',
+          reason: 'Rating: timeout'
+        },
+        null
+      ],
+      message: 'Syncing 2/4'
+    });
+
+    expect(state).toEqual({
+      locale: 'en',
+      status: 'running',
+      current: 2,
+      total: 4,
+      applied: 4,
+      synced: 1,
+      failed: 1,
+      failures: [
+        {
+          dbId: 7,
+          releaseId: 123,
+          instanceId: 456,
+          artist: 'Artist',
+          title: 'Title',
+          reason: 'Rating: timeout'
+        }
+      ],
+      progressPercent: 50,
+      isTerminal: false,
+      message: 'Syncing 2/4'
+    });
+  });
+
+  it('classifies terminal import statuses and UI metadata', () => {
+    expect(isTerminalImportStatus('completed')).toBe(true);
+    expect(isTerminalImportStatus('partial')).toBe(true);
+    expect(isTerminalImportStatus('local_only')).toBe(true);
+    expect(isTerminalImportStatus('failed')).toBe(true);
+    expect(isTerminalImportStatus('running')).toBe(false);
+
+    expect(getImportResultTone('completed')).toBe('success');
+    expect(getImportResultTone('partial')).toBe('warning');
+    expect(getImportResultTone('local_only')).toBe('warning');
+    expect(getImportResultTone('failed')).toBe('error');
+    expect(getImportResultTone('idle')).toBe('neutral');
+
+    expect(getImportResultTitleKey('completed')).toBe('collection.importCompletedTitle');
+    expect(getImportResultTitleKey('partial')).toBe('collection.importPartialTitle');
+    expect(getImportResultTitleKey('local_only')).toBe('collection.importLocalOnlyTitle');
+    expect(getImportResultTitleKey('failed')).toBe('collection.importFailedTitle');
+    expect(getImportResultTitleKey('idle')).toBe('collection.done');
+
+    expect(getImportResultHelpKey('completed')).toBeNull();
+    expect(getImportResultHelpKey('partial')).toBe('collection.importPartialHelp');
+    expect(getImportResultHelpKey('local_only')).toBe('collection.importLocalOnlyHelp');
+    expect(getImportResultHelpKey('failed')).toBe('collection.importFailedHelp');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared sync/import status contract with normalized progress, terminal state, and result metadata
- Normalize sync and import status responses at route and API boundaries
- Update SyncButton and ImportButton to consume normalized progress fields

## Test Plan
- npm test
- npm run build