### PR TITLE
perf: stabilize collection table rendering

### DIFF
--- a/src/components/CollectionTable.jsx
+++ b/src/components/CollectionTable.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { getMarketplaceStatusLabelKey, hasPricedMarketplaceValue } from '../../shared/contracts/marketplace.js';
 import { formatCurrency, joinNames } from '../lib/format';
 import { useI18n } from '../lib/I18nContext';
@@ -124,8 +124,12 @@ const RENDERERS = {
 
 function CollectionTable({ releases, sortBy, sortOrder, onSort, onUpdate, visibleColumns, currency = 'EUR' }) {
   const { t } = useI18n();
-  const sortProps = { sortBy, sortOrder, onSort };
-  const activeColumns = COLUMNS.filter((c) => visibleColumns.includes(c.id));
+  const sortProps = useMemo(() => ({ sortBy, sortOrder, onSort }), [onSort, sortBy, sortOrder]);
+  const visibleColumnSet = useMemo(() => new Set(visibleColumns), [visibleColumns]);
+  const activeColumns = useMemo(
+    () => COLUMNS.filter((column) => visibleColumnSet.has(column.id)),
+    [visibleColumnSet]
+  );
 
   return (
     <div className="glass-panel overflow-hidden">
@@ -157,4 +161,4 @@ function CollectionTable({ releases, sortBy, sortOrder, onSort, onUpdate, visibl
   );
 }
 
-export default CollectionTable;
+export default memo(CollectionTable);

--- a/src/lib/collectionTableState.js
+++ b/src/lib/collectionTableState.js
@@ -1,0 +1,12 @@
+import { MANDATORY } from './columns.js';
+
+export const COLLECTION_PAGE_LIMIT = 20;
+export const COLLECTION_TABLE_VIRTUALIZATION_THRESHOLD = 100;
+
+export function shouldVirtualizeCollectionTable(rowCount) {
+  return Number(rowCount) > COLLECTION_TABLE_VIRTUALIZATION_THRESHOLD;
+}
+
+export function buildCollectionTableVisibleColumns(visibleColumns = []) {
+  return [...new Set([...MANDATORY, ...visibleColumns])];
+}

--- a/src/pages/Collection.jsx
+++ b/src/pages/Collection.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import CollectionTable from '../components/CollectionTable';
 import ColumnToggle from '../components/ColumnToggle';
@@ -9,7 +9,8 @@ import { CollectionSkeleton } from '../components/LoadingSkeletons';
 import SearchBar from '../components/SearchBar';
 import { api } from '../lib/api';
 import { useAuth } from '../lib/AuthContext';
-import { DEFAULT_VISIBLE, COLUMNS, MANDATORY } from '../lib/columns';
+import { DEFAULT_VISIBLE, COLUMNS } from '../lib/columns';
+import { buildCollectionTableVisibleColumns, COLLECTION_PAGE_LIMIT } from '../lib/collectionTableState';
 import { formatNumber } from '../lib/format';
 import { useI18n } from '../lib/I18nContext';
 import { useToast } from '../lib/ToastContext';
@@ -72,13 +73,13 @@ function Collection() {
     setDisplayCurrency(currency || DEFAULT_CURRENCY);
   }, [currency]);
 
-  async function load(nextPage = page, nextFilters = filters, nextSortBy = sortBy, nextSortOrder = sortOrder, nextCurrency = displayCurrency) {
+  const load = useCallback(async (nextPage = page, nextFilters = filters, nextSortBy = sortBy, nextSortOrder = sortOrder, nextCurrency = displayCurrency) => {
     try {
       setLoading(true);
       const response = await api.getCollection({
         ...nextFilters,
         page: nextPage,
-        limit: 20,
+        limit: COLLECTION_PAGE_LIMIT,
         sortBy: nextSortBy,
         sortOrder: nextSortOrder,
         currency: nextCurrency
@@ -89,7 +90,7 @@ function Collection() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [displayCurrency, filters, page, sortBy, sortOrder, t, toast]);
 
   useEffect(() => {
     api.getPreference('collection_visible_columns').then(({ value }) => {
@@ -127,19 +128,19 @@ function Collection() {
 
   const activeFilterCount = useMemo(() => Object.values(filters).filter(Boolean).length, [filters]);
 
-  function syncFilterParams(nextFilters) {
+  const syncFilterParams = useCallback((nextFilters) => {
     setSearchParams(new URLSearchParams(getActiveCollectionFilters(nextFilters)));
-  }
+  }, [setSearchParams]);
 
-  function handleFilterChange(key, value) {
+  const handleFilterChange = useCallback((key, value) => {
     const next = { ...filters, [key]: value };
     setFilters(next);
     setPage(1);
     syncFilterParams(next);
     load(1, next, sortBy, sortOrder, displayCurrency);
-  }
+  }, [displayCurrency, filters, load, sortBy, sortOrder, syncFilterParams]);
 
-  async function handleCurrencyChange(nextCurrency) {
+  const handleCurrencyChange = useCallback(async (nextCurrency) => {
     setDisplayCurrency(nextCurrency);
 
     try {
@@ -147,15 +148,15 @@ function Collection() {
     } catch (error) {
       toast.error(t('collection.loadError', { error: error.message }));
     }
-  }
+  }, [setCurrencyPreference, t, toast]);
 
-  function handleSort(column) {
+  const handleSort = useCallback((column) => {
     const nextOrder = sortBy === column && sortOrder === 'asc' ? 'desc' : 'asc';
     setSortBy(column);
     setSortOrder(nextOrder);
-  }
+  }, [sortBy, sortOrder]);
 
-  function handleColumnToggle(columnId) {
+  const handleColumnToggle = useCallback((columnId) => {
     setVisibleColumns((prev) => {
       const next = prev.includes(columnId)
         ? prev.filter((id) => id !== columnId)
@@ -175,7 +176,7 @@ function Collection() {
 
       return next;
     });
-  }
+  }, [sortBy, t, toast]);
 
   async function persistSavedViews(nextViews, successKey) {
     const previousViews = savedViews;
@@ -222,7 +223,7 @@ function Collection() {
     setSavedViewName('');
   }
 
-  function handleApplySavedView(viewId) {
+  const handleApplySavedView = useCallback((viewId) => {
     const view = savedViews.find((item) => item.id === viewId);
     if (!view) {
       return;
@@ -237,7 +238,7 @@ function Collection() {
     setVisibleColumns(nextVisibleColumns);
     syncFilterParams(view.filters);
     load(1, view.filters, view.sortBy, view.sortOrder, displayCurrency);
-  }
+  }, [displayCurrency, load, savedViews, syncFilterParams]);
 
   async function handleDeleteSavedView() {
     if (!selectedSavedViewId) {
@@ -249,7 +250,7 @@ function Collection() {
     setSelectedSavedViewId('');
   }
 
-  async function handleUpdate(release, patch) {
+  const handleUpdate = useCallback(async (release, patch) => {
     const previous = payload.releases;
     const optimistic = previous.map((item) => {
       if (item.id !== release.id) {
@@ -272,12 +273,16 @@ function Collection() {
       setPayload((current) => ({ ...current, releases: previous }));
       toast.error(t('collection.saveError', { error: error.message }));
     }
-  }
+  }, [payload.releases, t, toast]);
 
   const totalLabel = t('collection.results', { count: formatNumber(payload.pagination.total || 0) });
   const filterLabel = activeFilterCount
     ? t('collection.activeFilters', { count: formatNumber(activeFilterCount) })
     : t('collection.noFilters');
+  const tableVisibleColumns = useMemo(
+    () => buildCollectionTableVisibleColumns(visibleColumns),
+    [visibleColumns]
+  );
 
   return (
     <div className="space-y-6">
@@ -394,7 +399,7 @@ function Collection() {
       {loading ? (
         <CollectionSkeleton />
       ) : (
-        <CollectionTable releases={payload.releases} sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} onUpdate={handleUpdate} visibleColumns={[...new Set([...MANDATORY, ...visibleColumns])]} currency={displayCurrency} />
+        <CollectionTable releases={payload.releases} sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} onUpdate={handleUpdate} visibleColumns={tableVisibleColumns} currency={displayCurrency} />
       )}
 
       <div className="glass-panel flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">

--- a/tests/collection-table-state.test.js
+++ b/tests/collection-table-state.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COLLECTION_PAGE_LIMIT,
+  COLLECTION_TABLE_VIRTUALIZATION_THRESHOLD,
+  buildCollectionTableVisibleColumns,
+  shouldVirtualizeCollectionTable
+} from '../src/lib/collectionTableState.js';
+
+describe('collection table state helpers', () => {
+  it('keeps collection pages within the simple table threshold', () => {
+    expect(COLLECTION_PAGE_LIMIT).toBe(20);
+    expect(COLLECTION_TABLE_VIRTUALIZATION_THRESHOLD).toBe(100);
+    expect(shouldVirtualizeCollectionTable(COLLECTION_PAGE_LIMIT)).toBe(false);
+    expect(shouldVirtualizeCollectionTable(50)).toBe(false);
+    expect(shouldVirtualizeCollectionTable(100)).toBe(false);
+    expect(shouldVirtualizeCollectionTable(101)).toBe(true);
+  });
+
+  it('builds a stable visible column id list with mandatory columns first', () => {
+    expect(buildCollectionTableVisibleColumns(['year', 'artist', 'year', 'listingPrice'])).toEqual([
+      'cover',
+      'artist',
+      'title',
+      'year',
+      'listingPrice'
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Centralize collection table page limit at 20 and document the 100-row virtualization threshold
- Memoize collection table visible column IDs and table callback props
- Memoize CollectionTable column derivation and wrap the table in React.memo while preserving the simple paginated table

## Test Plan
- npm test
- npm run build

## Stacking
- Stacked on #25 (saved-collection-views) because Plan 3.2 touches the same Collection page code.