### PR TITLE
perf: split route bundles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,23 @@
+import { lazy, Suspense } from 'react';
 import { Link, NavLink, Route, Routes } from 'react-router-dom';
-import Collection from './pages/Collection';
-import CollectionWall from './pages/CollectionWall';
-import Dashboard from './pages/Dashboard';
-import Login from './pages/Login';
-import ReleaseDetail from './pages/ReleaseDetail';
-import Settings from './pages/Settings';
-import Setup from './pages/Setup';
 import { useAuth } from './lib/AuthContext';
 import { DashboardStatsProvider, useDashboardStats } from './lib/DashboardStatsContext';
 import { useI18n } from './lib/I18nContext';
 import VinylBadge from './components/VinylBadge';
+
+const Dashboard = lazy(() => import('./pages/Dashboard'));
+const Collection = lazy(() => import('./pages/Collection'));
+const CollectionWall = lazy(() => import('./pages/CollectionWall'));
+const ReleaseDetail = lazy(() => import('./pages/ReleaseDetail'));
+const Settings = lazy(() => import('./pages/Settings'));
+const Login = lazy(() => import('./pages/Login'));
+const Setup = lazy(() => import('./pages/Setup'));
+
+function AppLoading() {
+  const { t } = useI18n();
+
+  return <div className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-4 text-slate-300">{t('app.loading')}</div>;
+}
 
 function AppLayoutFrame() {
   const { user, logout } = useAuth();
@@ -52,13 +60,15 @@ function AppLayoutFrame() {
         </header>
 
         <main className="flex-1">
-          <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/collection" element={<Collection />} />
-            <Route path="/wall" element={<CollectionWall />} />
-            <Route path="/release/:id" element={<ReleaseDetail />} />
-            <Route path="/settings" element={<Settings />} />
-          </Routes>
+          <Suspense fallback={<AppLoading />}>
+            <Routes>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/collection" element={<Collection />} />
+              <Route path="/wall" element={<CollectionWall />} />
+              <Route path="/release/:id" element={<ReleaseDetail />} />
+              <Route path="/settings" element={<Settings />} />
+            </Routes>
+          </Suspense>
         </main>
       </div>
     </div>
@@ -75,18 +85,25 @@ function AppLayout() {
 
 function App() {
   const { loading, needsBootstrap, loggedIn } = useAuth();
-  const { t } = useI18n();
 
   if (loading) {
-    return <div className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-4 text-slate-300">{t('app.loading')}</div>;
+    return <AppLoading />;
   }
 
   if (needsBootstrap) {
-    return <Setup />;
+    return (
+      <Suspense fallback={<AppLoading />}>
+        <Setup />
+      </Suspense>
+    );
   }
 
   if (!loggedIn) {
-    return <Login />;
+    return (
+      <Suspense fallback={<AppLoading />}>
+        <Login />
+      </Suspense>
+    );
   }
 
   return <AppLayout />;

--- a/tests/app-code-splitting.test.js
+++ b/tests/app-code-splitting.test.js
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const appSource = readFileSync(new URL('../src/App.jsx', import.meta.url), 'utf8');
+const lazyPages = [
+  'Dashboard',
+  'Collection',
+  'CollectionWall',
+  'ReleaseDetail',
+  'Settings',
+  'Login',
+  'Setup'
+];
+
+describe('App route code splitting', () => {
+  it('lazy loads page modules instead of statically importing them', () => {
+    for (const page of lazyPages) {
+      expect(appSource).not.toContain(`import ${page} from './pages/${page}'`);
+      expect(appSource).toContain(`const ${page} = lazy(() => import('./pages/${page}'))`);
+    }
+  });
+
+  it('wraps lazy routes with Suspense using the existing app loading copy', () => {
+    expect(appSource).toContain("import { lazy, Suspense } from 'react'");
+    expect(appSource).toContain('<Suspense fallback={<AppLoading />}>');
+    expect(appSource).toContain("t('app.loading')");
+  });
+});


### PR DESCRIPTION
## Summary
- Lazy-load top-level page modules from `App.jsx` so authenticated routes, setup, and login split into separate route chunks.
- Reuse the existing localized app loading copy as the Suspense fallback.
- Add a regression test that prevents page modules from being reintroduced as static imports.

## Test Plan
- [x] `npm test -- tests/app-code-splitting.test.js`
- [x] `npm run build` (entry chunk is 244.66 kB gzip 76.07 kB; no large main chunk warning)
- [x] `npm test`